### PR TITLE
Adding src/main/kotlin to alpha-event-handler project

### DIFF
--- a/server/jvm/alpha-eventhandler/src/main/kotlin/global/genesis/readme.md
+++ b/server/jvm/alpha-eventhandler/src/main/kotlin/global/genesis/readme.md
@@ -1,0 +1,1 @@
+# place state machine definitions here


### PR DESCRIPTION
As part of the dev training, the user is supposed to create the structure itself, which doesn't feel right as the other packages are already in places.

This PR simples adds the src/main/kotlin with the package global.genesis containing a simple readme.md file inside - following the existing pattern on other modules.